### PR TITLE
[Feat] 고민 게시판 API 연동 및 UI 

### DIFF
--- a/src/app/chatting/page.tsx
+++ b/src/app/chatting/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import React, { useState, useEffect, useRef } from 'react'
+
+const Chatting = () => {
+  const chatRoomId = 1
+  const member = 1
+  const [messages, setMessages] = useState<string[]>([])
+  const [input, setInput] = useState<string>('')
+  const [isConnected, setIsConnected] = useState<boolean>(false)
+  const socketRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    const socket = new WebSocket(
+      `wss://lc3cc1cnma.execute-api.ap-northeast-2.amazonaws.com/mssaem?chatRoomId=${chatRoomId}&member=${member}`,
+    )
+
+    socket.onopen = () => {
+      console.log('WebSocket Opened')
+      setIsConnected(true)
+    }
+
+    socket.onmessage = (event: MessageEvent<string>) => {
+      console.log('WebSocket Message:', event.data)
+      setMessages((prev) => [...prev, event.data])
+    }
+
+    socket.onerror = (error: Event) => {
+      console.error('WebSocket Error:', error)
+    }
+
+    socket.onclose = () => {
+      console.log('WebSocket is closed')
+      setIsConnected(false)
+    }
+
+    socketRef.current = socket
+
+    return () => {
+      socket.close()
+    }
+  }, [chatRoomId, member])
+
+  const sendMessage = () => {
+    if (socketRef.current && input.trim() !== '') {
+      const message = {
+        action: 'sendMessage',
+        chatRoomId: 1,
+        message: input,
+      }
+      socketRef.current.send(JSON.stringify(message))
+      setInput('')
+    }
+  }
+
+  const disconnect = () => {
+    if (socketRef.current) {
+      socketRef.current.close()
+      socketRef.current = null
+      setIsConnected(false)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Chatting</h1>
+      <div>
+        {messages.map((msg, index) => (
+          <div key={index}>{msg}</div>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyPress={(e) => {
+          if (e.key === 'Enter') {
+            sendMessage()
+          }
+        }}
+      />
+      <button onClick={sendMessage}>Send</button>
+      {isConnected && <button onClick={disconnect}>Disconnect</button>}
+    </div>
+  )
+}
+
+export default Chatting

--- a/src/app/worry/[id]/page.tsx
+++ b/src/app/worry/[id]/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Button from '@/components/common/Button'
+import Container from '@/components/common/Container'
+import { useParams } from 'next/navigation'
+import { useWorryDetail } from '@/service/worry/useWorryService'
+import WorryProfile from '@/components/worry/WorryProfile'
+
+const WorryDetail = () => {
+  const { id } = useParams()
+  const { data: worryDetail } = useWorryDetail(Number(id))
+
+  return (
+    <>
+      <div className="text-title3 text-maindark font-semibold my-5">
+        M쌤 매칭을 기다리는 고민
+      </div>
+      <Container color="purple">
+        <div className="flex justify-end gap-2.5 mb-5">
+          <Button text="수정" color="PURPLE" size="small" onClick={() => {}} />
+          <Button text="삭제" color="PURPLE" size="small" onClick={() => {}} />
+        </div>
+        <div className="h-[1px] bg-main" />
+        {worryDetail && (
+          <>
+            <div className="flex justify-between my-7.5">
+              <WorryProfile
+                profileImgUrl={worryDetail.memberSimpleInfo.profileImgUrl}
+                nickName={worryDetail.memberSimpleInfo.nickName}
+                strFromMbti={worryDetail.memberSimpleInfo.mbti}
+                strToMbti={worryDetail.targetMbti}
+              />
+              <div className="flex gap-3.5 text-caption text-gray2">
+                <p>조회수 {worryDetail.hits}회</p>
+                <p>{worryDetail.createdAt}</p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <p className="text-title3 font-bold">{worryDetail.title}</p>
+              <div
+                className="text-body text-mainblack"
+                dangerouslySetInnerHTML={{ __html: worryDetail.content }}
+              />
+            </div>
+          </>
+        )}
+        <div className="h-[1px] bg-main" />
+        <div className="flex justify-center">
+          <Button
+            text="채팅 시작"
+            color="PURPLE"
+            size="small"
+            onClick={() => {}}
+            className="my-10"
+          />
+        </div>
+      </Container>
+    </>
+  )
+}
+
+export default WorryDetail

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -1,0 +1,7 @@
+import Container from '@/components/common/Container'
+
+const WorryPage = () => {
+  return <Container color="purple">dfasfd</Container>
+}
+
+export default WorryPage

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -1,7 +1,76 @@
+'use client'
+
 import Container from '@/components/common/Container'
+import MbtiSelect from '@/components/worry/MbtiSelect'
+import WorryBoard from '@/components/worry/WorryBoard'
+import {
+  useSolvedWorryList,
+  useWaitingWorryList,
+} from '@/service/worry/useWorryService'
+import { useState } from 'react'
 
 const WorryPage = () => {
-  return <Container color="purple">dfasfd</Container>
+  const [waitingStrFromMbti, setWaitingStrFromMbti] = useState('ALL')
+  const [waitingStrToMbti, setWaitingStrToMbti] = useState('ALL')
+  const [solvedStrFromMbti, setSolvedStrFromMbti] = useState('ALL')
+  const [solvedStrToMbti, setSolvedStrToMbti] = useState('ALL')
+
+  const { data: waitingWorryList } = useWaitingWorryList(
+    0,
+    10,
+    waitingStrFromMbti,
+    waitingStrToMbti,
+  )
+  const { data: solvedWorryList } = useSolvedWorryList(
+    0,
+    10,
+    solvedStrFromMbti,
+    solvedStrToMbti,
+  )
+
+  return (
+    <div className="flex flex-col">
+      <div className="text-title3 text-maindark font-semibold m-5">
+        M쌤 매칭을 기다리는 고민
+      </div>
+      <Container color="purple">
+        <MbtiSelect
+          strFromMbti={waitingStrFromMbti}
+          strToMbti={waitingStrToMbti}
+          setStrFromMbti={setWaitingStrFromMbti}
+          setStrToMbti={setWaitingStrToMbti}
+        />
+        <div className="h-[1px] bg-main" />
+        {waitingWorryList &&
+          waitingWorryList.result.map((worry) => (
+            <>
+              <WorryBoard key={worry.id} worryBoard={worry} />
+              <div className="h-[1px] bg-main" />
+            </>
+          ))}
+      </Container>
+
+      <div className="text-title3 text-maindark font-semibold m-5">
+        해결 완료된 고민
+      </div>
+      <Container color="purple">
+        <MbtiSelect
+          strFromMbti={solvedStrFromMbti}
+          strToMbti={solvedStrToMbti}
+          setStrFromMbti={setSolvedStrFromMbti}
+          setStrToMbti={setSolvedStrToMbti}
+        />
+        <div className="h-[1px] bg-main" />
+        {solvedWorryList &&
+          solvedWorryList.result.map((worry) => (
+            <>
+              <WorryBoard key={worry.id} worryBoard={worry} />
+              <div className="h-[1px] bg-main" />
+            </>
+          ))}
+      </Container>
+    </div>
+  )
 }
 
 export default WorryPage

--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -2,8 +2,8 @@
 
 import { BoardI } from '@/model/Board'
 import Image from 'next/image'
-import Profile from '../common/Profile'
 import { useRouter } from 'next/navigation'
+import Profile from '../common/Profile'
 
 export interface BoardProps {
   board: BoardI

--- a/src/components/board/MbtiCategories.stories.tsx
+++ b/src/components/board/MbtiCategories.stories.tsx
@@ -1,25 +1,17 @@
 import { Meta, StoryFn } from '@storybook/react'
-import MbtiCategories from './MbtiCategories'
+import MbtiCategories, { MbtiCategoriesProps } from './MbtiCategories'
 
 export default {
   title: 'Board/MbtiCategories',
   component: MbtiCategories,
 } as Meta
 
-const Template: StoryFn = (args) => <MbtiCategories {...args} />
+const Template: StoryFn<MbtiCategoriesProps> = (args) => (
+  <MbtiCategories {...args} />
+)
 
 export const Primary = Template.bind({})
 Primary.args = {
-  title: '카페에서 남친이랑 싸웠어',
-  content: '내가 말을 “만약에"라고 시작하면 너무 기빨린대',
-  imgUrl: '/images/common/thumbnail.svg',
-  likeCount: 30,
-  commentCount: 18,
-  createdAt: '24.07.25',
-  memberSimpleInfo: {
-    profileImgUrl: '/images/common/default.svg',
-    nickName: '유보라',
-    mbti: 'enfp',
-    badge: '엠비티어른',
-  },
+  selectedMbti: 'ISTJ',
+  setMbti: () => {},
 }

--- a/src/components/board/MbtiCategories.tsx
+++ b/src/components/board/MbtiCategories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/service/board/useBoardService'
 import { useState } from 'react'
 
-interface MbtiCategoriesProps {
+export interface MbtiCategoriesProps {
   selectedMbti: string
   setMbti: (mbti: string) => void
 }

--- a/src/components/worry/MbtiSelect.stories.tsx
+++ b/src/components/worry/MbtiSelect.stories.tsx
@@ -1,12 +1,19 @@
 import { Meta, StoryFn } from '@storybook/react'
-import MbtiSelect from './MbtiSelect'
+import MbtiSelect, { MbtiSelectProps } from './MbtiSelect'
 
 export default {
   title: 'Worry/MbtiSelect',
   component: MbtiSelect,
 } as Meta
 
-const Template: StoryFn = () => <MbtiSelect />
+const Template: StoryFn<MbtiSelectProps> = (args: MbtiSelectProps) => (
+  <MbtiSelect {...args} />
+)
 
 export const Primary = Template.bind({})
-Primary.args = {}
+Primary.args = {
+  strFromMbti: 'ISTJ',
+  strToMbti: 'ENFJ',
+  setStrFromMbti: () => {},
+  setStrToMbti: () => {},
+}

--- a/src/components/worry/MbtiSelect.tsx
+++ b/src/components/worry/MbtiSelect.tsx
@@ -4,27 +4,39 @@ import Image from 'next/image'
 import { useState } from 'react'
 import Dropdown from '@/components/worry/Dropdown'
 
-const MbtiSelect = () => {
-  const [selectedLeftType, setSelectedLeftType] = useState('전체')
-  const [selectedRightType, setSelectedRightType] = useState('전체')
+interface MbtiSelectProps {
+  strFromMbti: string
+  strToMbti: string
+  setStrFromMbti: (str: string) => void
+  setStrToMbti: (str: string) => void
+}
+
+const MbtiSelect = ({
+  strFromMbti,
+  strToMbti,
+  setStrFromMbti,
+  setStrToMbti,
+}: MbtiSelectProps) => {
   const [showLeftDropdown, setShowLeftDropdown] = useState(false)
   const [showRightDropdown, setShowRightDropdown] = useState(false)
 
   const handleLeftTypeClick = (type: string) => {
-    setSelectedLeftType(type)
+    setStrFromMbti(type === '전체' ? 'ALL' : type)
     setShowLeftDropdown(false)
   }
 
   const handleRightTypeClick = (type: string) => {
-    setSelectedRightType(type)
+    setStrToMbti(type === '전체' ? 'ALL' : type)
     setShowRightDropdown(false)
   }
+
+  const displayType = (type: string) => (type === 'ALL' ? '전체' : type)
 
   return (
     <div className="flex relative w-full">
       <div className="flex justify-between items-center gap-4 mb-4">
         <Dropdown
-          selectedType={selectedLeftType}
+          selectedType={displayType(strFromMbti)}
           showDropdown={showLeftDropdown}
           onToggleDropdown={() => setShowLeftDropdown(!showLeftDropdown)}
           onSelectType={handleLeftTypeClick}
@@ -36,7 +48,7 @@ const MbtiSelect = () => {
           height={7}
         />
         <Dropdown
-          selectedType={selectedRightType}
+          selectedType={displayType(strToMbti)}
           showDropdown={showRightDropdown}
           onToggleDropdown={() => setShowRightDropdown(!showRightDropdown)}
           onSelectType={handleRightTypeClick}

--- a/src/components/worry/MbtiSelect.tsx
+++ b/src/components/worry/MbtiSelect.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { useState } from 'react'
 import Dropdown from '@/components/worry/Dropdown'
 
-interface MbtiSelectProps {
+export interface MbtiSelectProps {
   strFromMbti: string
   strToMbti: string
   setStrFromMbti: (str: string) => void

--- a/src/components/worry/WorryBoard.stories.tsx
+++ b/src/components/worry/WorryBoard.stories.tsx
@@ -12,10 +12,13 @@ const Template: StoryFn<WorryBoardProps> = (args: WorryBoardProps) => (
 
 export const Primary = Template.bind({})
 Primary.args = {
-  title: '학생회장 선배 도와주세요ㅠㅠ',
-  content: '마음이 있는 것 같나요??',
-  memberMbti: 'ISTJ',
-  targetMbti: 'ESFP',
-  createdDate: '3분전',
-  imgUrl: '/images/common/thumbnail.svg',
+  worryBoard: {
+    id: 1,
+    title: '학생회장 선배 도와주세요ㅠㅠ',
+    content: '마음이 있는 것 같나요??',
+    memberMbti: 'ISTJ',
+    targetMbti: 'ESFP',
+    createdDate: '3분전',
+    imgUrl: '/images/common/thumbnail.svg',
+  },
 }

--- a/src/components/worry/WorryBoard.tsx
+++ b/src/components/worry/WorryBoard.tsx
@@ -1,19 +1,26 @@
 'use client'
 
 import Image from 'next/image'
-import { WorryBoardI } from '@/model/Worry'
+import { WorryI } from '@/model/Worry'
 import Button from '../common/Button'
 
 export interface WorryBoardProps {
-  worryBoard: WorryBoardI
+  worryBoard: WorryI
 }
+
+const MAX_CONTENT_LENGTH = 35
 
 const WorryBoard = ({ worryBoard }: WorryBoardProps) => {
   const { title, content, memberMbti, targetMbti, createdDate, imgUrl } =
     worryBoard
 
+  const truncatedContent =
+    content.length > MAX_CONTENT_LENGTH
+      ? `${content.substring(0, MAX_CONTENT_LENGTH)}...`
+      : content
+
   return (
-    <div className="flex justify-between items-center">
+    <div className="flex justify-between items-center my-7.5">
       <div className="flex flex-col gap-3.5">
         <div className="flex items-center gap-2.5">
           <Button text={memberMbti} color={memberMbti} size="badge" />
@@ -28,10 +35,13 @@ const WorryBoard = ({ worryBoard }: WorryBoardProps) => {
         </div>
         <div className="flex flex-col gap-1.75">
           <div className="text-title3 font-semibold">{title}</div>
-          <div className="text-body font-regular">{content}</div>
+          <div
+            className="text-body font-regular"
+            dangerouslySetInnerHTML={{ __html: truncatedContent }}
+          />
         </div>
       </div>
-      <Image src={imgUrl} alt="image" width={84} height={84} />
+      {imgUrl && <Image src={imgUrl} alt="image" width={84} height={84} />}
     </div>
   )
 }

--- a/src/components/worry/WorryBoard.tsx
+++ b/src/components/worry/WorryBoard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { WorryI } from '@/model/Worry'
+import { useRouter } from 'next/navigation'
 import Button from '../common/Button'
 
 export interface WorryBoardProps {
@@ -11,7 +12,9 @@ export interface WorryBoardProps {
 const MAX_CONTENT_LENGTH = 35
 
 const WorryBoard = ({ worryBoard }: WorryBoardProps) => {
-  const { title, content, memberMbti, targetMbti, createdDate, imgUrl } =
+  const router = useRouter()
+
+  const { id, title, content, memberMbti, targetMbti, createdDate, imgUrl } =
     worryBoard
 
   const truncatedContent =
@@ -20,7 +23,12 @@ const WorryBoard = ({ worryBoard }: WorryBoardProps) => {
       : content
 
   return (
-    <div className="flex justify-between items-center my-7.5">
+    <div
+      className="flex justify-between items-center my-7.5 cursor-pointer"
+      onClick={() => {
+        router.push(`/worry/${id}`)
+      }}
+    >
       <div className="flex flex-col gap-3.5">
         <div className="flex items-center gap-2.5">
           <Button text={memberMbti} color={memberMbti} size="badge" />

--- a/src/components/worry/WorryProfile.stories.tsx
+++ b/src/components/worry/WorryProfile.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryFn } from '@storybook/react'
+import WorryProfile, { WorryProfileProps } from './WorryProfile'
+
+export default {
+  title: 'Worry/WorryProfile',
+  component: WorryProfile,
+} as Meta<WorryProfileProps>
+
+const Template: StoryFn<WorryProfileProps> = (args: WorryProfileProps) => (
+  <WorryProfile {...args} />
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  profileImgUrl: '/images/common/default.svg',
+  nickName: '유보라',
+  strFromMbti: 'ISTJ',
+  strToMbti: 'ENFJ',
+}

--- a/src/components/worry/WorryProfile.tsx
+++ b/src/components/worry/WorryProfile.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import Image from 'next/image'
+import Button, { MBTI } from '../common/Button'
+
+export interface WorryProfileProps {
+  profileImgUrl: string
+  nickName: string
+  strFromMbti: MBTI
+  strToMbti: MBTI
+}
+
+const WorryProfile = ({
+  profileImgUrl,
+  nickName,
+  strFromMbti,
+  strToMbti,
+}: WorryProfileProps) => {
+  return (
+    <div className="flex items-center gap-4.5">
+      <div className="w-14 h-14 relative rounded-full overflow-hidden">
+        <Image
+          src={profileImgUrl}
+          alt="profile"
+          className="w-full h-full object-cover"
+          width={40}
+          height={40}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="text-headline font-semibold">{nickName} 님</div>
+        <div className="flex gap-2.5">
+          <Button text={strFromMbti} color={strFromMbti} size="badge" />
+          <Image
+            src="/images/worry/arrow_right.svg"
+            alt="arrow_right"
+            width={18}
+            height={7}
+          />
+          <Button text={strToMbti} color={strToMbti} size="badge" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default WorryProfile

--- a/src/model/Worry.ts
+++ b/src/model/Worry.ts
@@ -20,7 +20,7 @@ interface WorryList {
 interface WorryDetail {
   memberSimpleInfo: User
   worryBoardId: number
-  targetMbti: string
+  targetMbti: MBTI
   title: string
   content: string
   createdAt: string

--- a/src/model/Worry.ts
+++ b/src/model/Worry.ts
@@ -1,6 +1,7 @@
 import { MBTI } from '@/components/common/Button'
+import { User } from './User'
 
-interface WorryBoardI {
+interface WorryI {
   title: string
   content: string
   memberMbti: MBTI
@@ -9,4 +10,24 @@ interface WorryBoardI {
   imgUrl: string
 }
 
-export type { WorryBoardI }
+interface WorryList {
+  page: number
+  totalSize: number
+  result: WorryI[]
+}
+
+interface WorryDetail {
+  memberSimpleInfo: User
+  worryBoardId: number
+  targetMbti: string
+  title: string
+  content: string
+  createdAt: string
+  imgList: string[]
+  isEditAllowed: boolean
+  isChatAllowed: boolean
+  chatRoomId: number
+  hits: number
+}
+
+export type { WorryI, WorryList, WorryDetail }

--- a/src/model/Worry.ts
+++ b/src/model/Worry.ts
@@ -2,6 +2,7 @@ import { MBTI } from '@/components/common/Button'
 import { User } from './User'
 
 interface WorryI {
+  id: number
   title: string
   content: string
   memberMbti: MBTI

--- a/src/service/worry/WorryQueries.ts
+++ b/src/service/worry/WorryQueries.ts
@@ -1,0 +1,61 @@
+import WorryService, { WorryListProps, WorryPatchProps } from './WorryService'
+
+const queryKeys = {
+  worry: (worryId: number) => ['worry', worryId] as const,
+  worryList: ['worryList'] as const,
+  worryListNumber: ['worryListNumber'] as const,
+  bookmarkList: ['bookmarkList'] as const,
+}
+
+const queryOptions = {
+  worryList: {
+    queryKey: queryKeys.worryList,
+    queryFn: async ({ page, size, strFromMbti, strToMbti }: WorryListProps) => {
+      const res = await WorryService.getWaitingWorryList({
+        page,
+        size,
+        strFromMbti,
+        strToMbti,
+      })
+      return res.data
+    },
+  },
+
+  worryDetail: {
+    queryKey: (worryId: number) => queryKeys.worry(worryId),
+    queryFn: async (worryId: number) => {
+      const res = await WorryService.getWorryDetail(worryId)
+      return res.data
+    },
+  },
+
+  postWorry: {
+    queryKey: queryKeys.worryList,
+    mutationFn: async (worry: FormData): Promise<void> => {
+      await WorryService.postWorry(worry)
+    },
+  },
+
+  patchWorry: {
+    queryKey: (worryId: number) => queryKeys.worry(worryId),
+    mutationFn: async ({ id, worry }: WorryPatchProps): Promise<void> => {
+      await WorryService.patchWorry({ id, worry })
+    },
+  },
+
+  deleteWorry: {
+    queryKey: queryKeys.worryList,
+    mutationFn: async (worryId: number): Promise<void> => {
+      await WorryService.deleteWorry(worryId)
+    },
+  },
+
+  patchWorrySolved: {
+    queryKey: (worryId: number) => queryKeys.worry(worryId),
+    mutationFn: async (worryId: number): Promise<void> => {
+      await WorryService.patchWorrySolved(worryId)
+    },
+  },
+}
+
+export { queryKeys, queryOptions }

--- a/src/service/worry/WorryQueries.ts
+++ b/src/service/worry/WorryQueries.ts
@@ -3,13 +3,10 @@ import WorryService, { WorryListProps, WorryPatchProps } from './WorryService'
 const queryKeys = {
   worry: (worryId: number) => ['worry', worryId] as const,
   worryList: ['worryList'] as const,
-  worryListNumber: ['worryListNumber'] as const,
-  bookmarkList: ['bookmarkList'] as const,
 }
 
 const queryOptions = {
-  worryList: {
-    queryKey: queryKeys.worryList,
+  waitingWorryList: {
     queryFn: async ({ page, size, strFromMbti, strToMbti }: WorryListProps) => {
       const res = await WorryService.getWaitingWorryList({
         page,
@@ -20,38 +17,39 @@ const queryOptions = {
       return res.data
     },
   },
-
+  solvedWorryList: {
+    queryFn: async ({ page, size, strFromMbti, strToMbti }: WorryListProps) => {
+      const res = await WorryService.getSolvedWorryList({
+        page,
+        size,
+        strFromMbti,
+        strToMbti,
+      })
+      return res.data
+    },
+  },
   worryDetail: {
-    queryKey: (worryId: number) => queryKeys.worry(worryId),
     queryFn: async (worryId: number) => {
       const res = await WorryService.getWorryDetail(worryId)
       return res.data
     },
   },
-
   postWorry: {
-    queryKey: queryKeys.worryList,
     mutationFn: async (worry: FormData): Promise<void> => {
       await WorryService.postWorry(worry)
     },
   },
-
   patchWorry: {
-    queryKey: (worryId: number) => queryKeys.worry(worryId),
     mutationFn: async ({ id, worry }: WorryPatchProps): Promise<void> => {
       await WorryService.patchWorry({ id, worry })
     },
   },
-
   deleteWorry: {
-    queryKey: queryKeys.worryList,
-    mutationFn: async (worryId: number): Promise<void> => {
-      await WorryService.deleteWorry(worryId)
+    mutationFn: async (id: number): Promise<void> => {
+      await WorryService.deleteWorry(id)
     },
   },
-
   patchWorrySolved: {
-    queryKey: (worryId: number) => queryKeys.worry(worryId),
     mutationFn: async (worryId: number): Promise<void> => {
       await WorryService.patchWorrySolved(worryId)
     },

--- a/src/service/worry/WorryService.ts
+++ b/src/service/worry/WorryService.ts
@@ -1,0 +1,58 @@
+import Service from '@/apis/AxiosInstance'
+import { WorryDetail, WorryList } from '@/model/Worry'
+
+export interface WorryListProps {
+  page: number
+  size: number
+  strFromMbti: string
+  strToMbti: string
+}
+
+export interface WorryPatchProps {
+  id: number
+  worry: FormData
+}
+
+class WorryService extends Service {
+  getWaitingWorryList({ page, size, strFromMbti, strToMbti }: WorryListProps) {
+    return this.http.get<WorryList>(
+      `/worry-board/waiting/filter&page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
+    )
+  }
+
+  getSolvedWorryList({ page, size, strFromMbti, strToMbti }: WorryListProps) {
+    return this.http.get<WorryList>(
+      `/worry-board/solved/filter&page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
+    )
+  }
+
+  getWorryDetail(id: number) {
+    return this.http.get<WorryDetail>(`/worry-board/${id}`)
+  }
+
+  postWorry(worry: FormData) {
+    return this.http.post(`/member/worry-board`, worry, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+  }
+
+  patchWorry({ id, worry }: WorryPatchProps) {
+    return this.http.patch(`/member/worry-board/${id}`, worry, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+  }
+
+  deleteWorry(id: number) {
+    return this.http.delete(`/member/worry-board/${id}`)
+  }
+
+  patchWorrySolved(id: number) {
+    return this.http.patch(`/member/worry-board/${id}/solved`)
+  }
+}
+
+export default new WorryService()

--- a/src/service/worry/WorryService.ts
+++ b/src/service/worry/WorryService.ts
@@ -16,13 +16,13 @@ export interface WorryPatchProps {
 class WorryService extends Service {
   getWaitingWorryList({ page, size, strFromMbti, strToMbti }: WorryListProps) {
     return this.http.get<WorryList>(
-      `/worry-board/waiting/filter&page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
+      `/worry-board/waiting/filter?page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
     )
   }
 
   getSolvedWorryList({ page, size, strFromMbti, strToMbti }: WorryListProps) {
     return this.http.get<WorryList>(
-      `/worry-board/solved/filter&page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
+      `/worry-board/solved/filter?page=${page}&size=${size}&strFromMbti=${strFromMbti}&strToMbti=${strToMbti}`,
     )
   }
 

--- a/src/service/worry/useWorryService.ts
+++ b/src/service/worry/useWorryService.ts
@@ -1,0 +1,80 @@
+import {
+  useMutation,
+  useQuery,
+  UseMutationOptions,
+} from '@tanstack/react-query'
+import { queryOptions } from './WorryQueries'
+
+interface WorryPatchProps {
+  id: number
+  worry: FormData
+}
+
+const useWaitingWorryList = (
+  page: number,
+  size: number,
+  strFromMbti: string,
+  strToMbti: string,
+) =>
+  useQuery({
+    ...queryOptions.worryList,
+    queryKey: ['worryList', page, size, strFromMbti, strToMbti],
+    queryFn: () =>
+      queryOptions.worryList.queryFn({ page, size, strFromMbti, strToMbti }),
+  })
+
+const useWorryDetail = (worryId: number) =>
+  useQuery({
+    ...queryOptions.worryDetail,
+    queryKey: ['worryDetail', worryId],
+    queryFn: () => queryOptions.worryDetail.queryFn(worryId),
+  })
+
+const usePostWorry = () => {
+  const mutationFn = (worry: FormData): Promise<void> =>
+    queryOptions.postWorry.mutationFn(worry)
+
+  const options: UseMutationOptions<void, Error, FormData, unknown> = {
+    mutationFn,
+  }
+  return useMutation<void, Error, FormData>(options)
+}
+
+const usePatchWorry = () => {
+  const mutationFn = ({ id, worry }: WorryPatchProps): Promise<void> =>
+    queryOptions.patchWorry.mutationFn({ id, worry })
+
+  const options: UseMutationOptions<void, Error, WorryPatchProps, unknown> = {
+    mutationFn,
+  }
+  return useMutation<void, Error, WorryPatchProps>(options)
+}
+
+const useDeleteWorry = () => {
+  const mutationFn = (id: number): Promise<void> =>
+    queryOptions.deleteWorry.mutationFn(id)
+
+  const options: UseMutationOptions<void, Error, number, unknown> = {
+    mutationFn,
+  }
+  return useMutation<void, Error, number>(options)
+}
+
+const usePatchWorrySolved = () => {
+  const mutationFn = (worryId: number): Promise<void> =>
+    queryOptions.patchWorrySolved.mutationFn(worryId)
+
+  const options: UseMutationOptions<void, Error, number, unknown> = {
+    mutationFn,
+  }
+  return useMutation<void, Error, number>(options)
+}
+
+export {
+  useWaitingWorryList,
+  useWorryDetail,
+  usePostWorry,
+  usePatchWorry,
+  useDeleteWorry,
+  usePatchWorrySolved,
+}

--- a/src/service/worry/useWorryService.ts
+++ b/src/service/worry/useWorryService.ts
@@ -1,34 +1,53 @@
 import {
   useMutation,
-  useQuery,
   UseMutationOptions,
+  useQuery,
 } from '@tanstack/react-query'
 import { queryOptions } from './WorryQueries'
-
-interface WorryPatchProps {
-  id: number
-  worry: FormData
-}
+import { WorryPatchProps } from './WorryService'
 
 const useWaitingWorryList = (
   page: number,
   size: number,
   strFromMbti: string,
   strToMbti: string,
-) =>
-  useQuery({
-    ...queryOptions.worryList,
+) => {
+  return useQuery({
     queryKey: ['worryList', page, size, strFromMbti, strToMbti],
     queryFn: () =>
-      queryOptions.worryList.queryFn({ page, size, strFromMbti, strToMbti }),
+      queryOptions.waitingWorryList.queryFn({
+        page,
+        size,
+        strFromMbti,
+        strToMbti,
+      }),
   })
+}
 
-const useWorryDetail = (worryId: number) =>
-  useQuery({
-    ...queryOptions.worryDetail,
+const useSolvedWorryList = (
+  page: number,
+  size: number,
+  strFromMbti: string,
+  strToMbti: string,
+) => {
+  return useQuery({
+    queryKey: ['worryList', page, size, strFromMbti, strToMbti],
+    queryFn: () =>
+      queryOptions.solvedWorryList.queryFn({
+        page,
+        size,
+        strFromMbti,
+        strToMbti,
+      }),
+  })
+}
+
+const useWorryDetail = (worryId: number) => {
+  return useQuery({
     queryKey: ['worryDetail', worryId],
     queryFn: () => queryOptions.worryDetail.queryFn(worryId),
   })
+}
 
 const usePostWorry = () => {
   const mutationFn = (worry: FormData): Promise<void> =>
@@ -72,6 +91,7 @@ const usePatchWorrySolved = () => {
 
 export {
   useWaitingWorryList,
+  useSolvedWorryList,
   useWorryDetail,
   usePostWorry,
   usePatchWorry,


### PR DESCRIPTION
## 연관 이슈

- #11

## 📁 작업 내용

- 고민글 필터링 조회 - M쌤 매칭을 기다리는
- 고민글 필터링 조회 - 해결된 고민
- 고민글 상세 조회
- 고민글 작성
- 고민글 수정
- 고민글 삭제
- 해결 완료 처리하기
- 고민게시판 전체 UI
- 고민게시판 디테일 UI

## 📁 구현 결과 

![image](https://github.com/user-attachments/assets/8d93120e-29fa-42e7-87af-632666e74c82)

## 📁 기타 사항
