### PR TITLE
[Feat] Pagination, SearchBar 공통 컴포넌트

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react'
-import '../src/app/globals.css'
+import '../src/styles/globals.css'
 
 const preview: Preview = {
   parameters: {

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -4,14 +4,20 @@ import Board from '@/components/board/Board'
 import MbtiCategories from '@/components/board/MbtiCategories'
 import Button from '@/components/common/Button'
 import Container from '@/components/common/Container'
+import Pagination from '@/components/common/Pagination'
 import { useBoardList } from '@/service/board/useBoardService'
 import { useState } from 'react'
 
 const BoardPage = () => {
   const [mbti, setMbti] = useState<string>('all')
-  // const [page, setPage] = useState<number>(0)
+  const [page, setPage] = useState<number>(1)
+  const pageSize = 6
 
-  const { data } = useBoardList(mbti, 0, 6)
+  const { data: boardList } = useBoardList(mbti, page - 1, pageSize)
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage)
+  }
 
   return (
     <>
@@ -29,13 +35,25 @@ const BoardPage = () => {
           />
         </div>
         <div className="h-[1px] bg-main" />
-        {data &&
-          data.result.map((board) => (
-            <>
-              <Board key={board.id} board={board} />
+        {boardList &&
+          boardList.result.map((board) => (
+            <div key={board.id}>
+              <Board board={board} />
               <div className="h-[1px] bg-main" />
-            </>
+            </div>
           ))}
+
+        {/* Pagination 컴포넌트 추가 */}
+        {boardList && (
+          <div className="mt-5">
+            <Pagination
+              itemsCount={boardList.totalSize}
+              pageSize={pageSize}
+              currentPage={page}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        )}
       </Container>
     </>
   )

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -44,12 +44,10 @@ const BoardPage = () => {
             </div>
           ))}
 
-        {/* Pagination 컴포넌트 추가 */}
         {boardList && (
           <div className="mt-5">
             <Pagination
-              itemsCount={boardList.totalSize}
-              pageSize={pageSize}
+              pagesCount={boardList.totalSize}
               currentPage={page}
               onPageChange={handlePageChange}
             />

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -5,6 +5,7 @@ import MbtiCategories from '@/components/board/MbtiCategories'
 import Button from '@/components/common/Button'
 import Container from '@/components/common/Container'
 import Pagination from '@/components/common/Pagination'
+import SearchBar from '@/components/common/SearchBar'
 import { useBoardList } from '@/service/board/useBoardService'
 import { useState } from 'react'
 
@@ -54,6 +55,9 @@ const BoardPage = () => {
             />
           </div>
         )}
+        <div className="my-7.5">
+          <SearchBar onSearch={() => {}} />
+        </div>
       </Container>
     </>
   )

--- a/src/app/discussion/page.tsx
+++ b/src/app/discussion/page.tsx
@@ -4,6 +4,7 @@ import DiscussionBoard from '@/components/discussion/DiscussionBoard'
 import Pagination from '@/components/common/Pagination'
 import { useDiscussionList } from '@/service/discussion/useDiscussionService'
 import { useState } from 'react'
+import SearchBar from '@/components/common/SearchBar'
 
 const DiscussionPage = () => {
   const [page, setPage] = useState<number>(1)
@@ -39,6 +40,10 @@ const DiscussionPage = () => {
           />
         </div>
       )}
+
+      <div className="my-7.5">
+        <SearchBar onSearch={() => {}} />
+      </div>
     </>
   )
 }

--- a/src/app/discussion/page.tsx
+++ b/src/app/discussion/page.tsx
@@ -33,8 +33,7 @@ const DiscussionPage = () => {
       {discussionList && (
         <div className="mt-5">
           <Pagination
-            itemsCount={discussionList.totalSize}
-            pageSize={pageSize}
+            pagesCount={discussionList.totalSize}
             currentPage={page}
             onPageChange={handlePageChange}
           />

--- a/src/app/discussion/page.tsx
+++ b/src/app/discussion/page.tsx
@@ -1,28 +1,44 @@
 'use client'
 
 import DiscussionBoard from '@/components/discussion/DiscussionBoard'
+import Pagination from '@/components/common/Pagination'
 import { useDiscussionList } from '@/service/discussion/useDiscussionService'
+import { useState } from 'react'
 
 const DiscussionPage = () => {
-  const { data: discussionList } = useDiscussionList(0, 10)
+  const [page, setPage] = useState<number>(1)
+  const pageSize = 6
+
+  const { data: discussionList } = useDiscussionList(page - 1, pageSize)
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage)
+  }
 
   return (
     <>
       <div className="text-title3 text-maindark font-semibold my-5">
         MBTI 과몰입 토론
       </div>
-      <div className="flex flex-col gap-2.5 sm:gap-16.5">
+      <div className="flex flex-col">
         {discussionList &&
           discussionList.result.map((discussion) => (
-            <>
-              <DiscussionBoard
-                key={discussion.id}
-                discussionBoard={discussion}
-              />
-              <div className="h-[1px] bg-gray4" />
-            </>
+            <div key={discussion.id} className="flex flex-col">
+              <DiscussionBoard discussionBoard={discussion} />
+              <div className="h-[1px] bg-gray4 my-2.5 sm:my-12.5" />
+            </div>
           ))}
       </div>
+
+      {discussionList && (
+        <div className="mt-5">
+          <Pagination
+            itemsCount={discussionList.totalSize}
+            pageSize={pageSize}
+            currentPage={page}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -66,8 +66,7 @@ const WorryPage = () => {
         {waitingWorryList && (
           <div className="mt-5">
             <Pagination
-              itemsCount={waitingWorryList.totalSize}
-              pageSize={pageSize}
+              pagesCount={waitingWorryList.totalSize}
               currentPage={waitingPage}
               onPageChange={handleWaitingPageChange}
             />

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -3,6 +3,7 @@
 import Container from '@/components/common/Container'
 import MbtiSelect from '@/components/worry/MbtiSelect'
 import WorryBoard from '@/components/worry/WorryBoard'
+import Pagination from '@/components/common/Pagination'
 import {
   useSolvedWorryList,
   useWaitingWorryList,
@@ -10,23 +11,35 @@ import {
 import { useState } from 'react'
 
 const WorryPage = () => {
+  const [waitingPage, setWaitingPage] = useState<number>(1)
+  const [solvedPage, setSolvedPage] = useState<number>(1)
+
   const [waitingStrFromMbti, setWaitingStrFromMbti] = useState('ALL')
   const [waitingStrToMbti, setWaitingStrToMbti] = useState('ALL')
   const [solvedStrFromMbti, setSolvedStrFromMbti] = useState('ALL')
   const [solvedStrToMbti, setSolvedStrToMbti] = useState('ALL')
 
+  const pageSize = 6
+
   const { data: waitingWorryList } = useWaitingWorryList(
-    0,
-    10,
+    waitingPage - 1,
+    pageSize,
     waitingStrFromMbti,
     waitingStrToMbti,
   )
   const { data: solvedWorryList } = useSolvedWorryList(
-    0,
-    10,
+    solvedPage - 1,
+    pageSize,
     solvedStrFromMbti,
     solvedStrToMbti,
   )
+
+  const handleWaitingPageChange = (newPage: number) => {
+    setWaitingPage(newPage)
+  }
+  const handleSolvedPageChange = (newPage: number) => {
+    setSolvedPage(newPage)
+  }
 
   return (
     <div className="flex flex-col">
@@ -43,11 +56,22 @@ const WorryPage = () => {
         <div className="h-[1px] bg-main" />
         {waitingWorryList &&
           waitingWorryList.result.map((worry) => (
-            <>
-              <WorryBoard key={worry.id} worryBoard={worry} />
+            <div key={worry.id}>
+              <WorryBoard worryBoard={worry} />
               <div className="h-[1px] bg-main" />
-            </>
+            </div>
           ))}
+
+        {waitingWorryList && (
+          <div className="mt-5">
+            <Pagination
+              itemsCount={waitingWorryList.totalSize}
+              pageSize={pageSize}
+              currentPage={waitingPage}
+              onPageChange={handleWaitingPageChange}
+            />
+          </div>
+        )}
       </Container>
 
       <div className="text-title3 text-maindark font-semibold my-5">
@@ -63,11 +87,22 @@ const WorryPage = () => {
         <div className="h-[1px] bg-main" />
         {solvedWorryList &&
           solvedWorryList.result.map((worry) => (
-            <>
-              <WorryBoard key={worry.id} worryBoard={worry} />
+            <div key={worry.id}>
+              <WorryBoard worryBoard={worry} />
               <div className="h-[1px] bg-main" />
-            </>
+            </div>
           ))}
+
+        {solvedWorryList && (
+          <div className="mt-5">
+            <Pagination
+              itemsCount={solvedWorryList.totalSize}
+              pageSize={pageSize}
+              currentPage={solvedPage}
+              onPageChange={handleSolvedPageChange}
+            />
+          </div>
+        )}
       </Container>
     </div>
   )

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -9,6 +9,7 @@ import {
   useWaitingWorryList,
 } from '@/service/worry/useWorryService'
 import { useState } from 'react'
+import SearchBar from '@/components/common/SearchBar'
 
 const WorryPage = () => {
   const [waitingPage, setWaitingPage] = useState<number>(1)
@@ -103,6 +104,10 @@ const WorryPage = () => {
             />
           </div>
         )}
+
+        <div className="my-7.5">
+          <SearchBar onSearch={() => {}} />
+        </div>
       </Container>
     </div>
   )

--- a/src/app/worry/page.tsx
+++ b/src/app/worry/page.tsx
@@ -96,8 +96,7 @@ const WorryPage = () => {
         {solvedWorryList && (
           <div className="mt-5">
             <Pagination
-              itemsCount={solvedWorryList.totalSize}
-              pageSize={pageSize}
+              pagesCount={solvedWorryList.totalSize}
               currentPage={solvedPage}
               onPageChange={handleSolvedPageChange}
             />

--- a/src/components/chatting/ChattingProfile.tsx
+++ b/src/components/chatting/ChattingProfile.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import ChattingProfileI from '@/model/Chatting'
 import Image from 'next/image'
+import { ChattingProfileI } from '@/model/Chatting'
 import Button from '../common/Button'
 
 export interface ChattingProfileProps {

--- a/src/components/common/Pagination.stories.tsx
+++ b/src/components/common/Pagination.stories.tsx
@@ -8,8 +8,7 @@ export default {
 } as Meta
 
 const Template: StoryFn<PaginationProps> = ({
-  itemsCount,
-  pageSize,
+  pagesCount,
   currentPage: initialCurrentPage,
   onPageChange,
 }: PaginationProps) => {
@@ -22,8 +21,7 @@ const Template: StoryFn<PaginationProps> = ({
 
   return (
     <Pagination
-      itemsCount={itemsCount}
-      pageSize={pageSize}
+      pagesCount={pagesCount}
       currentPage={currentPage}
       onPageChange={handlePageChange}
     />
@@ -32,8 +30,7 @@ const Template: StoryFn<PaginationProps> = ({
 
 export const Primary = Template.bind({})
 Primary.args = {
-  itemsCount: 45,
-  pageSize: 10,
+  pagesCount: 5,
   currentPage: 1,
-  onPageChange: (page: number) => console.log(`Current page: ${page}`),
+  onPageChange: () => {},
 }

--- a/src/components/common/Pagination.stories.tsx
+++ b/src/components/common/Pagination.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import Pagination, { PaginationProps } from '@/components/common/Pagination'
+import { Meta, StoryFn } from '@storybook/react'
+
+export default {
+  title: 'Common/Pagination',
+  component: Pagination,
+} as Meta
+
+const Template: StoryFn<PaginationProps> = ({
+  itemsCount,
+  pageSize,
+  currentPage: initialCurrentPage,
+  onPageChange,
+}: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(initialCurrentPage)
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page)
+    onPageChange(page)
+  }
+
+  return (
+    <Pagination
+      itemsCount={itemsCount}
+      pageSize={pageSize}
+      currentPage={currentPage}
+      onPageChange={handlePageChange}
+    />
+  )
+}
+
+export const Primary = Template.bind({})
+Primary.args = {
+  itemsCount: 45,
+  pageSize: 10,
+  currentPage: 1,
+  onPageChange: (page: number) => console.log(`Current page: ${page}`),
+}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -29,11 +29,16 @@ const Pagination = ({
     (_, i) => startPage + i,
   )
 
+  const handlePageChange = (page: number) => {
+    onPageChange(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' }) // 화면을 최상단으로 부드럽게 스크롤
+  }
+
   const handlePreviousGroup = () => {
     if (currentPageGroup > 1) {
       const newPageGroup = currentPageGroup - 1
       setCurrentPageGroup(newPageGroup)
-      onPageChange((newPageGroup - 1) * pagesPerGroup + 1)
+      handlePageChange((newPageGroup - 1) * pagesPerGroup + 1)
     }
   }
 
@@ -41,7 +46,7 @@ const Pagination = ({
     if (currentPageGroup < totalGroups) {
       const newPageGroup = currentPageGroup + 1
       setCurrentPageGroup(newPageGroup)
-      onPageChange((newPageGroup - 1) * pagesPerGroup + 1)
+      handlePageChange((newPageGroup - 1) * pagesPerGroup + 1)
     }
   }
 
@@ -67,7 +72,7 @@ const Pagination = ({
                   ? 'border-pointcolor1 bg-main4 text-maindark'
                   : 'border-transparent'
               }`}
-              onClick={() => onPageChange(page)}
+              onClick={() => handlePageChange(page)}
               aria-current={page === currentPage ? 'page' : undefined}
             >
               {page}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,42 +1,59 @@
+import React, { useState, useEffect } from 'react'
+
 export interface PaginationProps {
-  itemsCount: number
-  pageSize: number
+  pagesCount: number
   currentPage: number
   onPageChange: (page: number) => void
 }
 
 const Pagination = ({
-  itemsCount,
-  pageSize,
+  pagesCount,
   currentPage,
   onPageChange,
 }: PaginationProps) => {
-  const pagesCount = Math.ceil(itemsCount / pageSize)
-  if (pagesCount === 1) return null
+  const [currentPageGroup, setCurrentPageGroup] = useState<number>(1)
+  const pagesPerGroup = 5
 
-  const pages = Array.from({ length: pagesCount }, (_, i) => i + 1)
+  const totalGroups = Math.ceil(pagesCount / pagesPerGroup)
 
-  const handlePreviousPage = () => {
-    if (currentPage > 1) {
-      onPageChange(currentPage - 1)
+  useEffect(() => {
+    const newPageGroup = Math.ceil(currentPage / pagesPerGroup)
+    setCurrentPageGroup(newPageGroup)
+  }, [currentPage])
+
+  const startPage = (currentPageGroup - 1) * pagesPerGroup + 1
+  const endPage = Math.min(currentPageGroup * pagesPerGroup, pagesCount)
+
+  const pages = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i,
+  )
+
+  const handlePreviousGroup = () => {
+    if (currentPageGroup > 1) {
+      const newPageGroup = currentPageGroup - 1
+      setCurrentPageGroup(newPageGroup)
+      onPageChange((newPageGroup - 1) * pagesPerGroup + 1)
     }
   }
 
-  const handleNextPage = () => {
-    if (currentPage < pagesCount) {
-      onPageChange(currentPage + 1)
+  const handleNextGroup = () => {
+    if (currentPageGroup < totalGroups) {
+      const newPageGroup = currentPageGroup + 1
+      setCurrentPageGroup(newPageGroup)
+      onPageChange((newPageGroup - 1) * pagesPerGroup + 1)
     }
   }
 
   return (
     <nav>
       <ul className="flex justify-center items-center gap-3">
-        <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
+        <li className={`page-item ${currentPageGroup === 1 ? 'disabled' : ''}`}>
           <button
             type="button"
             className="text-headline text-gray2 font-semibold"
-            onClick={handlePreviousPage}
-            disabled={currentPage === 1}
+            onClick={handlePreviousGroup}
+            disabled={currentPageGroup === 1}
           >
             이전
           </button>
@@ -57,12 +74,16 @@ const Pagination = ({
             </button>
           </li>
         ))}
-        <li className={`${currentPage === pagesCount ? 'disabled' : ''}`}>
+        <li
+          className={`page-item ${
+            currentPageGroup === totalGroups ? 'disabled' : ''
+          }`}
+        >
           <button
             type="button"
             className="text-headline text-gray2 font-semibold"
-            onClick={handleNextPage}
-            disabled={currentPage === pagesCount}
+            onClick={handleNextGroup}
+            disabled={currentPageGroup === totalGroups}
           >
             다음
           </button>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,75 @@
+export interface PaginationProps {
+  itemsCount: number
+  pageSize: number
+  currentPage: number
+  onPageChange: (page: number) => void
+}
+
+const Pagination = ({
+  itemsCount,
+  pageSize,
+  currentPage,
+  onPageChange,
+}: PaginationProps) => {
+  const pagesCount = Math.ceil(itemsCount / pageSize)
+  if (pagesCount === 1) return null
+
+  const pages = Array.from({ length: pagesCount }, (_, i) => i + 1)
+
+  const handlePreviousPage = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1)
+    }
+  }
+
+  const handleNextPage = () => {
+    if (currentPage < pagesCount) {
+      onPageChange(currentPage + 1)
+    }
+  }
+
+  return (
+    <nav>
+      <ul className="flex justify-center items-center gap-3">
+        <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
+          <button
+            type="button"
+            className="text-headline text-gray2 font-semibold"
+            onClick={handlePreviousPage}
+            disabled={currentPage === 1}
+          >
+            이전
+          </button>
+        </li>
+        {pages.map((page) => (
+          <li key={page} className={`${page === currentPage ? 'active' : ''}`}>
+            <button
+              type="button"
+              className={`text-headline text-gray2 font-semibold w-8 h-8 border rounded-[3px] ${
+                page === currentPage
+                  ? 'border-pointcolor1 bg-main4 text-maindark'
+                  : 'border-transparent'
+              }`}
+              onClick={() => onPageChange(page)}
+              aria-current={page === currentPage ? 'page' : undefined}
+            >
+              {page}
+            </button>
+          </li>
+        ))}
+        <li className={`${currentPage === pagesCount ? 'disabled' : ''}`}>
+          <button
+            type="button"
+            className="text-headline text-gray2 font-semibold"
+            onClick={handleNextPage}
+            disabled={currentPage === pagesCount}
+          >
+            다음
+          </button>
+        </li>
+      </ul>
+    </nav>
+  )
+}
+
+export default Pagination

--- a/src/components/common/SearchBar.stories.tsx
+++ b/src/components/common/SearchBar.stories.tsx
@@ -1,0 +1,19 @@
+import SearchBar, { SearchBarProps } from '@/components/common/SearchBar'
+import { Meta, StoryFn } from '@storybook/react'
+
+export default {
+  title: 'Common/SearchBar',
+  component: SearchBar,
+} as Meta<SearchBarProps>
+
+const Template: StoryFn<SearchBarProps> = (args: SearchBarProps) => (
+  <SearchBar {...args} />
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  onSearch: (filter, query) => {
+    console.log('filter:', filter)
+    console.log('query:', query)
+  },
+}

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -26,11 +26,11 @@ const SearchBar = ({ onSearch }: SearchBarProps) => {
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-5.5 justify-center w-full">
       <select
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
-        className="border border-gray4 rounded-[5px] px-2 py-2.5 text-gray2 cursor-pointer focus:outline-none focus:border-gray4 "
+        className="border border-gray4 rounded-[5px] px-2 py-2.5 text-gray2 cursor-pointer focus:outline-none focus:border-gray4"
       >
         {options.map((option) => (
           <option
@@ -42,14 +42,14 @@ const SearchBar = ({ onSearch }: SearchBarProps) => {
           </option>
         ))}
       </select>
-      <div className="relative flex-grow">
+      <div className="relative flex-grow max-w-lg">
         <input
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="검색어를 입력해주세요."
-          className="border border-gray4 rounded-[5px] px-2 py-2.5 w-full pr-10 text-gray2 focus:outline-none focus:border-gray4 "
+          className="border border-gray4 rounded-[5px] px-2 py-2.5 w-full pr-10 text-gray2 focus:outline-none focus:border-gray4"
         />
         <button
           type="button"

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,0 +1,71 @@
+import Image from 'next/image'
+import React, { useState } from 'react'
+
+const options = [
+  { value: '제목+내용', label: '제목+내용' },
+  { value: '제목', label: '제목' },
+  { value: '내용', label: '내용' },
+]
+
+export interface SearchBarProps {
+  onSearch: (filter: string, query: string) => void
+}
+
+const SearchBar = ({ onSearch }: SearchBarProps) => {
+  const [filter, setFilter] = useState<string>('제목+내용')
+  const [query, setQuery] = useState<string>('')
+
+  const handleSearch = () => {
+    onSearch(filter, query)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch()
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="border border-gray4 rounded-[5px] px-2 py-2.5 text-gray2 cursor-pointer focus:outline-none focus:border-gray4 "
+      >
+        {options.map((option) => (
+          <option
+            key={option.value}
+            value={option.value}
+            className="text-gray2"
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <div className="relative flex-grow">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="검색어를 입력해주세요."
+          className="border border-gray4 rounded-[5px] px-2 py-2.5 w-full pr-10 text-gray2 focus:outline-none focus:border-gray4 "
+        />
+        <button
+          type="button"
+          onClick={handleSearch}
+          className="absolute right-2 top-1/2 transform -translate-y-1/2"
+        >
+          <Image
+            src="/images/common/search.svg"
+            alt="검색"
+            width={24}
+            height={24}
+          />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default SearchBar

--- a/src/model/Search.ts
+++ b/src/model/Search.ts
@@ -1,0 +1,23 @@
+import { BoardDetail } from './Board'
+import { DiscussionBoardI } from './Discussion'
+import { WorryI } from './Worry'
+
+interface BoardSearch {
+  page: number
+  totalSize: number
+  result: BoardDetail[]
+}
+
+interface WorrySearch {
+  page: number
+  totalSize: number
+  result: WorryI[]
+}
+
+interface DiscussionSearch {
+  page: number
+  totalSize: number
+  result: DiscussionBoardI[]
+}
+
+export type { BoardSearch, WorrySearch, DiscussionSearch }

--- a/src/service/search/SearchQueries.ts
+++ b/src/service/search/SearchQueries.ts
@@ -1,0 +1,89 @@
+import SearchService, { SearchProps } from './SearchService'
+
+const queryKeys = {
+  boardSearch: 'boardSearch',
+  solvedWorrySearch: 'solvedWorrySearch',
+  waitingWorrySearch: 'waitingWorrySearch',
+  discussionSearch: 'discussionSearch',
+}
+
+const queryOptions = {
+  boardSearch: {
+    queryKey: queryKeys.boardSearch,
+    queryFn: async ({
+      searchType,
+      keyword,
+      strMbti,
+      page,
+      size,
+    }: SearchProps) => {
+      const res = await SearchService.getBoardSearch({
+        searchType,
+        keyword,
+        strMbti,
+        page,
+        size,
+      })
+      return res.data
+    },
+  },
+
+  solvedWorrySearch: {
+    queryKey: queryKeys.boardSearch,
+    queryFn: async ({
+      searchType,
+      keyword,
+      strFromMbti,
+      strToMbti,
+      page,
+      size,
+    }: SearchProps) => {
+      const res = await SearchService.getSolvedWorrySearch({
+        searchType,
+        keyword,
+        strFromMbti,
+        strToMbti,
+        page,
+        size,
+      })
+      return res.data
+    },
+  },
+
+  waitingWorrySearch: {
+    queryKey: queryKeys.boardSearch,
+    queryFn: async ({
+      searchType,
+      keyword,
+      strFromMbti,
+      strToMbti,
+      page,
+      size,
+    }: SearchProps) => {
+      const res = await SearchService.getWaitingWorrySearch({
+        searchType,
+        keyword,
+        strFromMbti,
+        strToMbti,
+        page,
+        size,
+      })
+      return res.data
+    },
+  },
+
+  discussionSearch: {
+    queryKey: queryKeys.boardSearch,
+    queryFn: async ({ searchType, keyword, page, size }: SearchProps) => {
+      const res = await SearchService.getDiscussionSearch({
+        searchType,
+        keyword,
+        page,
+        size,
+      })
+      return res.data
+    },
+  },
+}
+
+export { queryKeys, queryOptions }

--- a/src/service/search/SearchService.ts
+++ b/src/service/search/SearchService.ts
@@ -1,0 +1,55 @@
+import Service from '@/apis/AxiosInstance'
+import { MBTI } from '@/components/common/Button'
+import { BoardSearch, WorrySearch } from '@/model/Search'
+
+export interface SearchProps {
+  searchType: number
+  keyword: string
+  strMbti?: MBTI
+  strFromMbti?: MBTI
+  strToMbti?: MBTI
+  page: number
+  size: number
+}
+
+class SearchService extends Service {
+  getBoardSearch({ searchType, keyword, strMbti, page, size }: SearchProps) {
+    return this.http.get<BoardSearch>(
+      `boards/search?searchType=${searchType}&keyword=${keyword}$strMbti=${strMbti}$page=${page}&size=${size}`,
+    )
+  }
+
+  getSolvedWorrySearch({
+    searchType,
+    keyword,
+    strFromMbti,
+    strToMbti,
+    page,
+    size,
+  }: SearchProps) {
+    return this.http.get<WorrySearch>(
+      `/worry-board/solved/search?searchType=${searchType}&keyword=${keyword}$strFromMbti=${strFromMbti}$strToMbti=${strToMbti}$page=${page}&size=${size}`,
+    )
+  }
+
+  getWaitingWorrySearch({
+    searchType,
+    keyword,
+    strFromMbti,
+    strToMbti,
+    page,
+    size,
+  }: SearchProps) {
+    return this.http.get<WorrySearch>(
+      `/worry-board/waiting/search?searchType=${searchType}&keyword=${keyword}$strFromMbti=${strFromMbti}$strToMbti=${strToMbti}$page=${page}&size=${size}`,
+    )
+  }
+
+  getDiscussionSearch({ searchType, keyword, page, size }: SearchProps) {
+    return this.http.get<BoardSearch>(
+      `/discussions/search?searchType=${searchType}&keyword=${keyword}$page=${page}&size=${size}`,
+    )
+  }
+}
+
+export default new SearchService()

--- a/src/service/search/useSearchService.ts
+++ b/src/service/search/useSearchService.ts
@@ -1,0 +1,108 @@
+import { useQuery } from '@tanstack/react-query'
+import { MBTI } from '@/components/common/Button'
+import { queryOptions } from './SearchQueries'
+
+const useBoardSearch = (
+  searchType: number,
+  keyword: string,
+  strMbti: MBTI,
+  page: number,
+  size: number,
+) =>
+  useQuery({
+    ...queryOptions.boardSearch,
+    queryKey: ['boardSearch', searchType, keyword, strMbti, page, size],
+    queryFn: () =>
+      queryOptions.boardSearch.queryFn({
+        searchType,
+        keyword,
+        strMbti,
+        page,
+        size,
+      }),
+  })
+
+const useSolvedWorrySearch = (
+  searchType: number,
+  keyword: string,
+  strFromMbti: MBTI,
+  strToMbti: MBTI,
+  page: number,
+  size: number,
+) =>
+  useQuery({
+    ...queryOptions.boardSearch,
+    queryKey: [
+      'solvedWorrySearch',
+      searchType,
+      keyword,
+      strFromMbti,
+      strToMbti,
+      page,
+      size,
+    ],
+    queryFn: () =>
+      queryOptions.boardSearch.queryFn({
+        searchType,
+        keyword,
+        strFromMbti,
+        strToMbti,
+        page,
+        size,
+      }),
+  })
+
+const useWaitingWorrySearch = (
+  searchType: number,
+  keyword: string,
+  strFromMbti: MBTI,
+  strToMbti: MBTI,
+  page: number,
+  size: number,
+) =>
+  useQuery({
+    ...queryOptions.boardSearch,
+    queryKey: [
+      'waitingWorrySearch',
+      searchType,
+      keyword,
+      strFromMbti,
+      strToMbti,
+      page,
+      size,
+    ],
+    queryFn: () =>
+      queryOptions.boardSearch.queryFn({
+        searchType,
+        keyword,
+        strFromMbti,
+        strToMbti,
+        page,
+        size,
+      }),
+  })
+
+const useDiscussionSearch = (
+  searchType: number,
+  keyword: string,
+  page: number,
+  size: number,
+) =>
+  useQuery({
+    ...queryOptions.boardSearch,
+    queryKey: ['discussionSearch', searchType, keyword, page, size],
+    queryFn: () =>
+      queryOptions.boardSearch.queryFn({
+        searchType,
+        keyword,
+        page,
+        size,
+      }),
+  })
+
+export {
+  useBoardSearch,
+  useSolvedWorrySearch,
+  useWaitingWorrySearch,
+  useDiscussionSearch,
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,8 @@ const config: Config = {
         alarm: '#FF5C5C',
         green: '#5BE1A9',
 
+        pointcolor1: '#AD71EA',
+
         gray1: '#4E4F4E',
         gray2: '#7A7A7B',
         gray3: '#A7A7A7',


### PR DESCRIPTION
## 연관 이슈

- close #21

## 📁 작업 내용

- Pagination 공통 컴포넌트
- Pagination 버튼 눌렀을 경우 최상단 이동
- Pagination 이전 다음 버튼 그룹 5개로
- SearchBar 공통 컴포넌트
- Search 관련 API 연동

## 📁 구현 결과 
![image](https://github.com/user-attachments/assets/37c01af8-d32b-43b3-b3a3-5b064a3dbb7f)

![image](https://github.com/user-attachments/assets/e2339950-4af0-4f9c-a601-184ec94a5f86)

## 📁 기타 사항
