### PR TITLE
[Fix] Comment 캐싱 오류

### DIFF
--- a/src/app/board/[id]/page.tsx
+++ b/src/app/board/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React, { useState } from 'react'
 import Image from 'next/image'
 import MbtiCategories from '@/components/board/MbtiCategories'
 import Button from '@/components/common/Button'
@@ -11,23 +12,32 @@ import {
 } from '@/service/board/useBoardService'
 import { useParams } from 'next/navigation'
 import CommentList from '@/components/board/CommentList'
+import Pagination from '@/components/common/Pagination' // Pagination 컴포넌트 import
 
 const BoardDetail = () => {
   const { id } = useParams()
   const { data: boardDetail } = useBoardDetail(Number(id))
   const { mutate } = usePostBoardLike()
 
+  // 페이지 상태 관리
+  const [currentPage, setCurrentPage] = useState(1)
+  const pageSize = 5
+
   const handleLikeToggle = () => {
     mutate(Number(id))
   }
 
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page)
+  }
+
   return (
-    <>
+    <div>
       {boardDetail && (
         <>
           <MbtiCategories selectedMbti={boardDetail.boardMbti} />
           <div className="text-title3 text-maindark font-semibold my-5">
-            {boardDetail.boardMbti === 'all' ? '전체' : boardDetail.boardMbti}{' '}
+            {boardDetail.boardMbti === 'all' ? '전체' : boardDetail.boardMbti}
             게시판
           </div>
           <Container color="purple">
@@ -76,14 +86,20 @@ const BoardDetail = () => {
                 onClick={handleLikeToggle}
               />
             </div>
+            <CommentList
+              id={Number(id)}
+              page={currentPage - 1}
+              size={pageSize}
+            />
+            <Pagination
+              pagesCount={Math.ceil(boardDetail.commentCount / pageSize)}
+              currentPage={currentPage}
+              onPageChange={handlePageChange}
+            />
           </Container>
         </>
       )}
-
-      <Container color="purple">
-        <CommentList id={Number(id)} page={0} size={10} />
-      </Container>
-    </>
+    </div>
   )
 }
 

--- a/src/components/auth/MemberListCount.tsx
+++ b/src/components/auth/MemberListCount.tsx
@@ -5,7 +5,8 @@ import {
 } from '@/service/worry/useWorryService'
 import { useDiscussionListMember } from '@/service/discussion/useDiscussionService'
 import { useCommentListMember } from '@/service/comment/useCommentService'
-import { useState } from 'react'
+import { useProfile } from '@/service/user/useUserService'
+import { useState, useEffect } from 'react'
 import { DiscussionBoardI } from '@/model/Discussion'
 import { WorryI } from '@/model/Worry'
 import { BoardI } from '@/model/Board'
@@ -16,20 +17,15 @@ import DiscussionBoard from '../discussion/DiscussionBoard'
 import WorryBoard from '../worry/WorryBoard'
 import Container from '../common/Container'
 
-const TABS = [
-  '내가 쓴 게시글',
-  '내가 쓴 토론글',
-  '내가 쓴 고민글',
-  '내가 쓴 댓글',
-  '내가 해결한 고민',
-]
-
 interface MemberListCountProps {
   id: number
 }
 
 const MemberListCount = ({ id }: MemberListCountProps) => {
-  const [activeTab, setActiveTab] = useState(TABS[0])
+  const [activeTab, setActiveTab] = useState('')
+  const [tabs, setTabs] = useState<string[]>([])
+
+  const { data: profile } = useProfile(id)
 
   const { data: boardList } = useBoardListMember(id, 0, 5)
   const { data: discussionList } = useDiscussionListMember(id, 0, 5)
@@ -37,54 +33,67 @@ const MemberListCount = ({ id }: MemberListCountProps) => {
   const { data: waitingWorryList } = useWaitingWorryListMember(id, 0, 5)
   const { data: commentList } = useCommentListMember(id, 0, 4)
 
+  useEffect(() => {
+    const nickName = profile && profile.teacherInfo.nickName
+    const newTabs = [
+      `${nickName} 쓴 게시글`,
+      `${nickName} 쓴 토론글`,
+      `${nickName} 쓴 고민글`,
+      `${nickName} 쓴 댓글`,
+      `${nickName} 해결한 고민`,
+    ]
+    setTabs(newTabs)
+    setActiveTab(newTabs[0])
+  }, [profile])
+
   const renderList = () => {
     switch (activeTab) {
-      case '내가 쓴 게시글':
+      case `${profile?.teacherInfo.nickName} 쓴 게시글`:
         return (
           boardList &&
           boardList.result.map((item: BoardI, index: number) => (
-            <div>
-              <Board key={index} board={item} />
+            <div key={index}>
+              <Board board={item} />
               <div className="h-[1px] bg-main my-7.5" />
             </div>
           ))
         )
-      case '내가 쓴 토론글':
+      case `${profile?.teacherInfo.nickName} 쓴 토론글`:
         return (
           discussionList &&
           discussionList.result.map((item: DiscussionBoardI, index: number) => (
-            <div>
-              <DiscussionBoard key={index} discussionBoard={item} />
+            <div key={index}>
+              <DiscussionBoard discussionBoard={item} />
               <div className="h-[1px] bg-main my-7.5" />
             </div>
           ))
         )
-      case '내가 쓴 고민글':
+      case `${profile?.teacherInfo.nickName} 쓴 고민글`:
         return (
           waitingWorryList &&
           waitingWorryList.result.map((item: WorryI, index: number) => (
-            <div>
-              <WorryBoard key={index} worryBoard={item} />
+            <div key={index}>
+              <WorryBoard worryBoard={item} />
               <div className="h-[1px] bg-main my-7.5" />
             </div>
           ))
         )
-      case '내가 해결한 고민':
+      case `${profile?.teacherInfo.nickName} 해결한 고민`:
         return (
           solvedWorryList &&
           solvedWorryList.result.map((item: WorryI, index: number) => (
-            <div>
-              <WorryBoard key={index} worryBoard={item} />
+            <div key={index}>
+              <WorryBoard worryBoard={item} />
               <div className="h-[1px] bg-main my-7.5" />
             </div>
           ))
         )
-      case '내가 쓴 댓글':
+      case `${profile?.teacherInfo.nickName} 쓴 댓글`:
         return (
           commentList &&
           commentList.result.map((item: CommentI, index: number) => (
-            <div>
-              <Comment key={index} comment={item} />
+            <div key={index}>
+              <Comment comment={item} />
               <div className="h-[1px] bg-main my-7.5" />
             </div>
           ))
@@ -97,7 +106,7 @@ const MemberListCount = ({ id }: MemberListCountProps) => {
   return (
     <div className="w-full bg-main3 rounded-t-7.5">
       <div className="flex overflow-x-auto border-b mb-4 scrollbar-hide">
-        {TABS.map((tab) => (
+        {tabs.map((tab) => (
           <button
             type="button"
             key={tab}

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -28,10 +28,8 @@ const UserProfile = ({ profile }: UserProfileProps) => {
           <Button text={badge} color={badge} size="badge" />
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <div className="text-title3 text-gray1 items-start font-semibold">
-          한 줄 소개
-        </div>
+      <div className="flex flex-col gap-2 self-start">
+        <div className="text-title3 text-gray1 font-semibold">한 줄 소개</div>
         <div className="text-body text-gray1 font-regular">{introduction}</div>
       </div>
     </div>

--- a/src/components/board/CommentList.tsx
+++ b/src/components/board/CommentList.tsx
@@ -1,7 +1,10 @@
 'use client'
 
+import { useState } from 'react'
 import { useCommentList } from '@/service/comment/useCommentService'
+import { CommentI } from '@/model/Comment'
 import Comment from './Comment'
+import ChattingInput from '../chatting/ChattingInput'
 
 interface CommentListProps {
   id: number
@@ -10,12 +13,64 @@ interface CommentListProps {
 }
 
 const CommentList = ({ id, page, size }: CommentListProps) => {
+  const [newComment, setNewComment] = useState<FormData>(new FormData())
   const { data: commentList } = useCommentList({ id, page, size })
 
+  const handleCommentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formData = new FormData()
+    formData.append('comment', e.target.value)
+    setNewComment(formData)
+  }
+
+  const handleShareBtnClick = () => {
+    console.log('share')
+  }
+  const handleReportBtnClick = () => {
+    console.log('report')
+  }
+  const handleCommentSubmit = () => {
+    console.log('submit')
+  }
+
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col">
+      <div className="flex justify-between">
+        <div className="text-maindark text-title3 font-semibold">
+          전체 댓글 {commentList && commentList.totalSize}개
+        </div>
+        <div className="flex gap-4 text-gray2 text-title3 font-semibold">
+          <button
+            type="button"
+            className="cursor-pointer"
+            onClick={handleShareBtnClick}
+          >
+            공유
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer"
+            onClick={handleReportBtnClick}
+          >
+            신고
+          </button>
+        </div>
+      </div>
+      <div className="h-[1px] bg-main my-4" />
       {commentList &&
-        commentList.result.map((comment) => <Comment comment={comment} />)}
+        commentList.result.map((comment: CommentI) => (
+          <>
+            <Comment key={comment.commentId} comment={comment} />
+            <div className="h-[1px] bg-main my-4" />
+          </>
+        ))}
+
+      <div className="mb-4">
+        <ChattingInput
+          value={newComment.get('comment')?.toString() || ''}
+          onChange={handleCommentChange}
+          onClick={handleCommentSubmit}
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/chatting/ChattingInput.tsx
+++ b/src/components/chatting/ChattingInput.tsx
@@ -4,11 +4,17 @@ import Button from '../common/Button'
 
 export interface ChattingInputProps {
   value: string
+  placeholder?: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onClick: () => void
 }
 
-const ChattingInput = ({ value, onChange, onClick }: ChattingInputProps) => {
+const ChattingInput = ({
+  value,
+  placeholder,
+  onChange,
+  onClick,
+}: ChattingInputProps) => {
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       onClick()
@@ -19,14 +25,19 @@ const ChattingInput = ({ value, onChange, onClick }: ChattingInputProps) => {
     <div className="flex w-full gap-3.75">
       <input
         type="text"
-        className="w-full text-gray2 text-headline font-semibold px-4 py-2 border border-main rounded-7.5 focus:outline-none focus:border-main"
+        className="w-full text-gray2 text-headline font-semibold px-4 py-3 border border-main rounded-7.5 focus:outline-none focus:border-main"
         value={value}
         onChange={onChange}
         onKeyPress={handleKeyPress}
+        placeholder={placeholder}
       />
       <Button text="등록" color="PURPLE" size="small" onClick={onClick} />
     </div>
   )
+}
+
+ChattingInput.defaultProps = {
+  placeholder: '',
 }
 
 export default ChattingInput

--- a/src/service/comment/CommentQueries.ts
+++ b/src/service/comment/CommentQueries.ts
@@ -5,40 +5,39 @@ import CommentService, {
 } from './CommentService'
 
 const queryKeys = {
-  commentList: ['commentList'] as const,
-  commentBest: ['commentBest'] as const,
-  discussionCommentList: ['discussionCommentList'] as const,
-  discussionCommentBest: ['discussionCommentBest'] as const,
+  commentList: (id: number) => ['commentList', id] as const,
+  commentBest: (id: number) => ['commentBest', id] as const,
+  discussionCommentList: (id: number) => ['discussionCommentList', id] as const,
+  discussionCommentBest: (id: number) => ['discussionCommentBest', id] as const,
 }
 
 const queryOptions = {
   // 게시판 댓글
-  commentList: {
-    queryKey: queryKeys.commentList,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  commentList: (id: number) => ({
+    queryKey: queryKeys.commentList(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getCommentList({ id, page, size })
       return res.data
     },
-  },
+  }),
 
-  commentListMember: {
-    queryKey: queryKeys.commentList,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  commentListMember: (id: number) => ({
+    queryKey: queryKeys.commentList(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getCommentListMember({ id, page, size })
       return res.data
     },
-  },
+  }),
 
-  commentBest: {
-    queryKey: queryKeys.commentBest,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  commentBest: (id: number) => ({
+    queryKey: queryKeys.commentBest(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getCommentBest({ id, page, size })
       return res.data
     },
-  },
+  }),
 
   postCommentLike: {
-    queryKey: queryKeys.commentList,
     mutationFn: async ({
       id,
       commentId,
@@ -48,7 +47,6 @@ const queryOptions = {
   },
 
   postComment: {
-    queryKey: queryKeys.commentList,
     mutationFn: async ({
       id,
       comment,
@@ -63,7 +61,6 @@ const queryOptions = {
   },
 
   deleteComment: {
-    queryKey: queryKeys.commentList,
     mutationFn: async ({
       id,
       commentId,
@@ -73,9 +70,9 @@ const queryOptions = {
   },
 
   // 토론 게시판 댓글
-  discussionCommentList: {
-    queryKey: queryKeys.discussionCommentList,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  discussionCommentList: (id: number) => ({
+    queryKey: queryKeys.discussionCommentList(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getDiscussionCommentList({
         id,
         page,
@@ -83,11 +80,11 @@ const queryOptions = {
       })
       return res.data
     },
-  },
+  }),
 
-  discussionCommentListMember: {
-    queryKey: queryKeys.discussionCommentList,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  discussionCommentListMember: (id: number) => ({
+    queryKey: queryKeys.discussionCommentList(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getDiscussionCommentListMember({
         id,
         page,
@@ -95,11 +92,11 @@ const queryOptions = {
       })
       return res.data
     },
-  },
+  }),
 
-  discussionCommentBest: {
-    queryKey: queryKeys.discussionCommentBest,
-    queryFn: async ({ id, page, size }: CommentListProps) => {
+  discussionCommentBest: (id: number) => ({
+    queryKey: queryKeys.discussionCommentBest(id),
+    queryFn: async ({ page, size }: Omit<CommentListProps, 'id'>) => {
       const res = await CommentService.getDiscussionCommentBest({
         id,
         page,
@@ -107,7 +104,7 @@ const queryOptions = {
       })
       return res.data
     },
-  },
+  }),
 
   postDiscussionCommentLike: {
     queryKey: queryKeys.discussionCommentList,

--- a/src/service/comment/useCommentService.ts
+++ b/src/service/comment/useCommentService.ts
@@ -13,23 +13,20 @@ import {
 // 게시판 댓글
 const useCommentList = ({ id, page, size }: CommentListProps) =>
   useQuery({
-    ...queryOptions.commentList,
-    queryKey: ['commentList'],
-    queryFn: () => queryOptions.commentList.queryFn({ id, page, size }),
+    ...queryOptions.commentList(id),
+    queryFn: () => queryOptions.commentList(id).queryFn({ page, size }),
   })
 
 const useCommentListMember = (id: number, page: number, size: number) =>
   useQuery({
-    ...queryOptions.commentListMember,
-    queryKey: ['commentListMember'],
-    queryFn: () => queryOptions.commentListMember.queryFn({ id, page, size }),
+    ...queryOptions.commentListMember(id),
+    queryFn: () => queryOptions.commentListMember(id).queryFn({ page, size }),
   })
 
 const useCommentBest = ({ id, page, size }: CommentListProps) =>
   useQuery({
-    ...queryOptions.commentBest,
-    queryKey: ['commentBest'],
-    queryFn: () => queryOptions.commentBest.queryFn({ id, page, size }),
+    ...queryOptions.commentBest(id),
+    queryFn: () => queryOptions.commentBest(id).queryFn({ page, size }),
   })
 
 const useCommentLike = () => {
@@ -71,26 +68,23 @@ const useDeleteComment = () => {
 // 토론 게시판 댓글
 const useDiscussionCommentList = ({ id, page, size }: CommentListProps) =>
   useQuery({
-    ...queryOptions.discussionCommentList,
-    queryKey: ['discussionCommentList'],
+    ...queryOptions.discussionCommentList(id),
     queryFn: () =>
-      queryOptions.discussionCommentList.queryFn({ id, page, size }),
+      queryOptions.discussionCommentList(id).queryFn({ page, size }),
   })
 
 const useDiscussionCommentListMember = ({ id, page, size }: CommentListProps) =>
   useQuery({
-    ...queryOptions.discussionCommentListMember,
-    queryKey: ['discussionCommentListMember'],
+    ...queryOptions.discussionCommentListMember(id),
     queryFn: () =>
-      queryOptions.discussionCommentListMember.queryFn({ id, page, size }),
+      queryOptions.discussionCommentListMember(id).queryFn({ page, size }),
   })
 
 const useDiscussionCommentBest = ({ id, page, size }: CommentListProps) =>
   useQuery({
-    ...queryOptions.discussionCommentBest,
-    queryKey: ['discussionCommentBest'],
+    ...queryOptions.discussionCommentBest(id),
     queryFn: () =>
-      queryOptions.discussionCommentBest.queryFn({ id, page, size }),
+      queryOptions.discussionCommentBest(id).queryFn({ page, size }),
   })
 
 const useDiscussionCommentLike = () => {


### PR DESCRIPTION
## 연관 이슈

- close #30

## 📁 작업 내용

queryKey가 게시물별로 고유하지 않아서, 캐싱된 댓글 데이터가 모든 게시물에 동일하게 적용됐습니다. 
이를 해결하기 위해 queryKey를 게시물 ID를 포함하는 형태로 고유하게 만들었습니다.

## 📁 구현 결과 

```
const queryKeys = {
  commentList: (id: number) => ['commentList', id] as const,
  commentBest: (id: number) => ['commentBest', id] as const,
  discussionCommentList: (id: number) => ['discussionCommentList', id] as const,
  discussionCommentBest: (id: number) => ['discussionCommentBest', id] as const,
}
```

## 📁 기타 사항
