### PR TITLE
[Fix] 로그인한 유저 정보 server side

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,15 @@
+import HotThreeBox from '@/components/home/HotThreeBox'
 import HotBoardBox from '@/components/home/HotBoardBox'
 import HotDiscussionBox from '@/components/home/HotDiscussionBox'
-import HotThreeBox from '@/components/home/HotThreeBox'
+import { fetchUserInfo } from '@/service/user/fetchUserInfo'
+import { User } from '@/model/User'
 
-export default function Home() {
+export default async function HomePage() {
+  const userInfo: User | null = await fetchUserInfo()
+
   return (
     <>
-      <HotThreeBox />
+      <HotThreeBox userInfo={userInfo} />
       <HotBoardBox />
       <HotDiscussionBox />
     </>

--- a/src/components/home/HotThreeBox.tsx
+++ b/src/components/home/HotThreeBox.tsx
@@ -1,14 +1,17 @@
 'use client'
 
 import { useHotThree } from '@/service/home/useHomeService'
-import { useUserInfo } from '@/service/user/useUserService'
+import { User } from '@/model/User'
 import HotThree from './HotThree'
 import NotLogin from '../auth/NotLogin'
 import Login from '../auth/Login'
 
-const HotThreeBox = () => {
+interface HotThreeBoxProps {
+  userInfo: User | null
+}
+
+const HotThreeBox = ({ userInfo }: HotThreeBoxProps) => {
   const { data: hotThree } = useHotThree()
-  const { data: userInfo } = useUserInfo()
 
   return (
     <>
@@ -53,6 +56,7 @@ const HotThreeBox = () => {
           </>
         ) : (
           <>
+            <NotLogin />
             {hotThree && (
               <>
                 <HotThree hotThree={hotThree} board="board" />
@@ -60,7 +64,6 @@ const HotThreeBox = () => {
                 <HotThree hotThree={hotThree} board="worry" />
               </>
             )}
-            <NotLogin />
           </>
         )}
       </div>

--- a/src/service/user/fetchUserInfo.ts
+++ b/src/service/user/fetchUserInfo.ts
@@ -1,0 +1,11 @@
+import UserService from '@/service/user/UserService'
+import { User } from '@/model/User'
+
+export const fetchUserInfo = async (): Promise<User | null> => {
+  try {
+    const response = await UserService.getUserInfo()
+    return response.data
+  } catch (error) {
+    return null
+  }
+}


### PR DESCRIPTION
## 연관 이슈

- #41 

## 📁 작업 내용

로그인을 해도 바로 로그인한 유저 정보가 불러와지지 않고, 새로고침을 해야만 보이는 문제가 발생했었다.

서버 사이드에서 데이터를 호출할 때는 React의 라이프사이클 훅(useEffect, useState 등)을 사용할 수 없으므로, 일반적으로 서버 사이드에서 데이터를 가져오는 커스텀 훅은 만들기 어렵다고 한다. React의 hook 또한 클라이언트 사이드에서만 사용할 수 있다.

원래는 react query를 사용하여 custom hook을 만들어 서버 호출을 하였지만, userInfo는 서버 사이드에서 미리 데이터를 가져와야 됐다. 그래서 서버 사이드에서 데이터를 가져오는 로직을 아래와 같이 일반 함수로 만들고, 필요한 곳에서 호출하여 사용할 수 있도록 하였다.

## 📁 구현 결과 

```
import UserService from '@/service/user/UserService'
import { User } from '@/model/User'

export const fetchUserInfo = async (): Promise<User | null> => {
  try {
    const response = await UserService.getUserInfo()
    return response.data
  } catch (error) {
    return null
  }
}

```

## 📁 기타 사항
